### PR TITLE
Set replyTo instead of from-header when sending

### DIFF
--- a/components/ContactForm.php
+++ b/components/ContactForm.php
@@ -90,7 +90,7 @@ class ContactForm extends ComponentBase{
         // If everything is fine - send an email
         Mail::send('laminsanneh.flexicontact::emails.message', post(), function($message)
         {
-            $message->from(post('email'), post('name'))
+            $message->replyTo(post('email'), post('name'))
                 ->to(Settings::get('recipient_email'), Settings::get('recipient_name'))
                 ->subject(Settings::get('subject'));
         });


### PR DESCRIPTION
I'm having issues, since some mail providers do not allow "from"-header that does not match the (in october configured SMTP-) authorization. Is there any disadvantage, if instead using "replyTo".
This way, a direct reply would address the sender and the authorization issue is solved. Otherwise the plugin user unknowingly changes the global october settings.
At least this works for me. btw thanks for the plugin!